### PR TITLE
Fix memory leak in problem

### DIFF
--- a/problems/graph_detect_cycle/files/Graph.c
+++ b/problems/graph_detect_cycle/files/Graph.c
@@ -125,6 +125,9 @@ bool adjacent(Graph g, Vertex u, Vertex v) {
 }
 
 void freeGraph(Graph g) {
+    for (Vertex v = 0; v < g->_nV; v++) {
+        free(g->_adjMatrix[v]);
+    }
     free(g->_adjMatrix);
     free(g);
 }


### PR DESCRIPTION
This fixes a memory leak that causes all the tests from `2521 autotest graph_detect_cycle` to fail.